### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A Model Context Protocol (MCP) server for interacting with Home Assistant. This server provides tools to control and monitor your Home Assistant devices through MCP-enabled applications.
 
+<a href="https://glama.ai/mcp/servers/io8m0yc5wq">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/io8m0yc5wq/badge" alt="Home Assistant Server MCP server" />
+</a>
+
 This project is part of the AI Model Context Protocol (MCP) ecosystem. For more information and documentation about MCP tools, visit [www.aimcp.info](http://www.aimcp.info).
 
 ## Features


### PR DESCRIPTION
This PR adds a badge for the [Home Assistant MCP Server](https://glama.ai/mcp/servers/io8m0yc5wq) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/io8m0yc5wq">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/io8m0yc5wq/badge" alt="Home Assistant Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.